### PR TITLE
Set sharejs state in correct way

### DIFF
--- a/lib/client/share-primus.js
+++ b/lib/client/share-primus.js
@@ -1,24 +1,26 @@
-(function (window) {
+define(function (require, exports, module) {
   'use strict';
+
+  var sharejs = require('sharejs');
 
   // Map Primus ready states to ShareJS ready states.
   var STATES = {};
   STATES[Primus.CLOSED] = 'disconnected';
-  STATES[Primus.OPENING] = 'connecting';
-  STATES[Primus.OPEN] = 'connected';
+  STATES[Primus.OPEN] = 'connecting';
 
   // Override Connection's bindToSocket method with an implementation
   // that understands Primus Stream.
-  window.sharejs.Connection.prototype.bindToSocket = function(stream) {
+  sharejs.Connection.prototype.bindToSocket = function(stream) {
     var connection = this;
-
     setState(stream.readyState);
-    this.canSend = this.state === 'connected'; // Primus can't send in connecting state.
 
     // Tiny facade so Connection can still send() messages.
     this.socket = {
       send: function(msg) {
         stream.write(msg);
+      },
+      close: function () {
+          stream.end();
       }
     };
 
@@ -27,7 +29,7 @@
         connection.handleMessage(msg);
       } catch (e) {
         connection.emit('error', e);
-        throw e
+        throw e;
       }
     });
 
@@ -37,8 +39,9 @@
 
     function setState(readyState) {
       var shareState = STATES[readyState];
-      connection._setState(shareState);
+      if (shareState) {
+        connection._setState(shareState);
+      }
     }
   };
-})(window);
-
+});


### PR DESCRIPTION
Open socket state is 'connecting' state for sharejs, state 'connected' will be set after init protocol with server side

Related https://github.com/codio/client/pull/2852
